### PR TITLE
Change user endpoints to right ones.

### DIFF
--- a/ CHANGELOG.md
+++ b/ CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to `cosenary/instagram` will be documented in this file.
 
 > Version 3.0 is in development and includes support for real-time subscriptions.
+<hr/>
+
+#April 4, 2018
+##The following endpoints are deprecated immediately:
+
+#####Follows and Relationships
+- `GET /users/self/follows`
+- `GET /users/self/followed-by`
+- `GET /users/self/requested-by`
+- `GET /users/{user-id}/relationship`
+- `POST /users/{user-id}/relationship`
+#####Commenting on Public Content
+- `GET /media/{media-id}/comments` (Deprecation not relevant when fetching comments for self media)
+- `POST /media/{media-id}/comments`
+- `DEL /media/{media-id}/comments/comment-id`
+#####Media
+- `GET /media/{media-id}`
+- `GET /media/shortcode/{shortcode}`
+#####Likes
+- `GET /media/{media-id}/likes`
+- `POST /media/{media-id}/likes`
+- `DEL /media/{media-id}/likes`
+#####User Search
+- `GET /users/{user-id}`
+- `GET /users/{user-id}/media/recent`
+- `GET /users/self/media/liked`
+- `GET /users/search`
+
+> Subscriptions - to receive notifications when media is posted Some information on Public Content returned through hashtag and location search will be removed - Name, Bio, Comments, Commenters, Follower Count, Following Count, Post Count, and Profile Picture
+
+https://www.instagram.com/developer/changelog/
+<hr/>
 
 **Instagram 2.2 - 04/10/2014**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ![Image](example/assets/instagram.png) Instagram PHP API V2
 
-> **Note:** On the 17 Nov 2015 [Instagram](http://developers.instagram.com/post/133424514006/instagram-platform-update) made [changes to their API ](https://instagram.com/developer/changelog/). Apps created before Nov 17, 2015 wont be affected until Jun 2016. Apps created on or after Nov 17 2015 will require to use their updated API. Please note that this library doesn't yet support their new updates. For more information, please see [#182](https://github.com/cosenary/Instagram-PHP-API/issues/182).
+> **Note:** Starting today (January 30), we are launching three new features on the Instagram Graph API designed to help businesses better manage their organic presence on Instagram. As part of our API changes, we will also be deprecating the older Instagram API Platform over the next two years beginning on July 31, 2018.Please see the full summary [here](https://developers.facebook.com/blog/post/2018/01/30/instagram-graph-api-updates/).
+
+> **Note:** On the 17 Nov 2015 [Instagram](http://developers.instagram.coThe following endpoints are deprecated immediately:m/post/133424514006/instagram-platform-update) made [changes to their API ](https://instagram.com/developer/changelog/). Apps created before Nov 17, 2015 wont be affected until Jun 2016. Apps created on or after Nov 17 2015 will require to use their updated API. Please note that this library doesn't yet support their new updates. For more information, please see [#182](https://github.com/cosenary/Instagram-PHP-API/issues/182).
 
 A PHP wrapper for the Instagram API. Feedback or bug reports are appreciated.
 
@@ -59,21 +61,6 @@ $code = $_GET['code'];
 $data = $instagram->getOAuthToken($code);
 
 echo 'Your username is: ' . $data->user->username;
-```
-
-### Get user likes
-
-```php
-// set user access token
-$instagram->setAccessToken($data);
-
-// get all user likes
-$likes = $instagram->getUserLikes();
-
-// take a look at the API response
-echo '<pre>';
-print_r($likes);
-echo '<pre>';
 ```
 
 **All methods return the API data `json_decode()` - so you can directly access the data.**
@@ -158,78 +145,17 @@ getLoginUrl(array(
 **Public methods**
 
 - `getUser($id)`
-- `searchUser($name, <$limit>)`
-- `getUserMedia($id, <$limit>)`
+- `searchUser()`
+- `getUserMedia($limit = 0, $min_id = null, $max_id = null)`
 
 **Authenticated methods**
 
 - `getUser()`
-- `getUserLikes(<$limit>)`
-- `getUserFeed(<$limit>)`
-- `getUserMedia(<$id>, <$limit>)`
-	- if an `$id` isn't defined or equals `'self'`, it returns the media of the logged in user
+- `getUserMedia( <$limit>)`
 
 > [Sample responses of the User Endpoints.](http://instagram.com/developer/endpoints/users/)
 
-### Relationship methods
-
-**Authenticated methods**
-
-- `getUserFollows($id, <$limit>)`
-- `getUserFollower($id, <$limit>)`
-- `getUserRelationship($id)`
-- `modifyRelationship($action, $user)`
-	- `$action` : Action command (follow / unfollow / block / unblock / approve / deny)
-	- `$user` : Target user id
-
-```php
-// Follow the user with the ID 1574083
-$instagram->modifyRelationship('follow', 1574083);
-```
-
 ---
-
-Please note that the `modifyRelationship()` method requires the `relationships` [scope](#get-login-url).
-
----
-
-> [Sample responses of the Relationship Endpoints.](http://instagram.com/developer/endpoints/relationships/)
-
-### Media methods
-
-**Public methods**
-
-- `getMedia($id)`
-	- authenticated users receive the info, whether the queried media is liked
-- `getPopularMedia()`
-- `searchMedia($lat, $lng, <$distance>, <$minTimestamp>, <$maxTimestamp>)`
-	- `$lat` and `$lng` are coordinates and have to be floats like: `48.145441892290336`,`11.568603515625`
-	- `$distance` : Radial distance in meter (default is 1km = 1000, max. is 5km = 5000)
-	- `$minTimestamp` : All media returned will be taken *later* than this timestamp (default: 5 days ago)
-	- `$maxTimestamp` : All media returned will be taken *earlier* than this timestamp (default: now)
-
-> [Sample responses of the Media Endpoints.](http://instagram.com/developer/endpoints/media/)
-
-### Comment methods
-
-**Public methods**
-
-- `getMediaComments($id)`
-
-**Authenticated methods**
-
-- `addMediaComment($id, $text)`
-	- **restricted access:** please email `apidevelopers[at]instagram.com` for access
-- `deleteMediaComment($id, $commentID)`
-	- the comment must be authored by the authenticated user
-
----
-
-Please note that the authenticated methods require the `comments` [scope](#get-login-url).
-
----
-
-> [Sample responses of the Comment Endpoints.](http://instagram.com/developer/endpoints/comments/)
 
 ### Tag methods
 
@@ -240,19 +166,6 @@ Please note that the authenticated methods require the `comments` [scope](#get-l
 - `searchTags($name)`
 
 > [Sample responses of the Tag Endpoints.](http://instagram.com/developer/endpoints/tags/)
-
-### Likes methods
-
-**Authenticated methods**
-
-- `getMediaLikes($id)`
-- `likeMedia($id)`
-- `deleteLikedMedia($id)`
-
-> How to like a Media: [Example usage](https://gist.github.com/3287237)
-> [Sample responses of the Likes Endpoints.](http://instagram.com/developer/endpoints/likes/)
-
-All `<...>` parameters are optional. If the limit is undefined, all available results will be returned.
 
 ## Instagram videos
 
@@ -350,19 +263,6 @@ Iteration with `do-while` loop.
 This example project, located in the `example/` folder, helps you to get started.
 The code is well documented and takes you through all required steps of the OAuth2 process.
 Credit for the awesome Instagram icons goes to [Ricardo de Zoete Pro](http://dribbble.com/RZDESIGN).
-
-#### More examples and tutorials:
-
-- [User likes](https://gist.github.com/cosenary/3287237)
-- [Follow user](https://gist.github.com/cosenary/8322459)
-- [User follower](https://gist.github.com/cosenary/7267139)
-- [Load more button](https://gist.github.com/cosenary/2975779)
-- [User most recent media](https://gist.github.com/cosenary/1711218)
-- [Instagram login](https://gist.github.com/cosenary/8803601)
-- [Instagram signup (9lessons tutorial)](http://www.9lessons.info/2012/05/login-with-instagram-php.html)
-- [Laravel Wrapper](https://github.com/vinkla/instagram)
-
-> Let me know if you have to share a code example, too.
 
 ## Changelog
 

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -188,7 +188,7 @@ class Instagram
             $params['max_id'] = $max_id;
         }
 
-        return $this->_makeCall('users/' . $id . '/media/recent', $params);
+        return $this->_makeCall('users/self/media/recent', $params);
     }
 
     /**

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -8,11 +8,11 @@ namespace MetzWeb\Instagram;
  * API Documentation: http://instagram.com/developer/
  * Class Documentation: https://github.com/cosenary/Instagram-PHP-API
  *
- * @author    Christian Metz
- * @since     30.10.2011
+ * @author Christian Metz
+ * @since 30.10.2011
  * @copyright Christian Metz - MetzWeb Networks 2011-2014
- * @version   2.2
- * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @version 2.2
+ * @license BSD http://www.opensource.org/licenses/bsd-license.php
  */
 class Instagram
 {
@@ -123,10 +123,8 @@ class Instagram
     public function getLoginUrl($scopes = array('basic'))
     {
         if (is_array($scopes) && count(array_intersect($scopes, $this->_scopes)) === count($scopes)) {
-            return self::API_OAUTH_URL.'?client_id='.$this->getApiKey().'&redirect_uri='.urlencode($this->getApiCallback()).'&scope='.implode(
-                    '+',
-                    $scopes
-                ).'&response_type=code';
+            return self::API_OAUTH_URL . '?client_id=' . $this->getApiKey() . '&redirect_uri=' . urlencode($this->getApiCallback()) . '&scope=' . implode('+',
+                    $scopes) . '&response_type=code';
         }
 
         throw new InstagramException("Error: getLoginUrl() - The parameter isn't an array or invalid scope permissions used.");
@@ -158,7 +156,7 @@ class Instagram
             $id = 'self';
         }
 
-        return $this->_makeCall('users/'.$id);
+        return $this->_makeCall('users/' . $id);
     }
 
     /**
@@ -190,14 +188,13 @@ class Instagram
             $params['max_id'] = $max_id;
         }
 
-        return $this->_makeCall('users/self/media/recent', $params);
+        return $this->_makeCall('users/' . $id . '/media/recent', $params);
     }
 
     /**
-     * @deprecated
      * Get the liked photos of a user.
      *
-     * @param int $limit       Limit of returned results
+     * @param int $limit Limit of returned results
      * @param int $max_like_id Return media liked before this id
      *
      * @return mixed
@@ -220,8 +217,8 @@ class Instagram
      * @deprecated
      * Get the list of users this user follows
      *
-     * @param int|string $id    Instagram user ID.
-     * @param int        $limit Limit of returned results
+     * @param int|string $id Instagram user ID.
+     * @param int $limit Limit of returned results
      *
      * @return void
      */
@@ -231,7 +228,6 @@ class Instagram
     }
 
     /**
-     * @deprecated
      * Get the list of users the authenticated user follows.
      *
      * @return mixed
@@ -244,15 +240,15 @@ class Instagram
             $params['count'] = $limit;
         }
 
-        return $this->_makeCall('users/'.$id.'/follows', $params);
+        return $this->_makeCall('users/' . $id . '/follows', $params);
     }
 
     /**
      * @deprecated
      * Get the list of users this user is followed by.
      *
-     * @param int|string $id    Instagram user ID
-     * @param int        $limit Limit of returned results
+     * @param int|string $id Instagram user ID
+     * @param int $limit Limit of returned results
      *
      * @return void
      */
@@ -262,7 +258,6 @@ class Instagram
     }
 
     /**
-     * @deprecated
      * Get the list of users this user is followed by.
      *
      * @return mixed
@@ -275,11 +270,10 @@ class Instagram
             $params['count'] = $limit;
         }
 
-        return $this->_makeCall('users/'.$id.'/followed-by', $params);
+        return $this->_makeCall('users/' . $id . '/followed-by', $params);
     }
 
     /**
-     * @deprecated
      * Get information about a relationship to another user.
      *
      * @param int $id Instagram user ID
@@ -288,7 +282,7 @@ class Instagram
      */
     public function getUserRelationship($id)
     {
-        return $this->_makeCall('users/'.$id.'/relationship');
+        return $this->_makeCall('users/' . $id . '/relationship');
     }
 
     /**
@@ -305,7 +299,7 @@ class Instagram
      * Modify the relationship between the current user and the target user.
      *
      * @param string $action Action command (follow/unfollow/approve/ignore)
-     * @param int    $user   Target user ID
+     * @param int $user Target user ID
      *
      * @return mixed
      *
@@ -314,7 +308,7 @@ class Instagram
     public function modifyRelationship($action, $user)
     {
         if (in_array($action, $this->_actions) && isset($user)) {
-            return $this->_makeCall('users/'.$user.'/relationship', array('action' => $action), 'POST');
+            return $this->_makeCall('users/' . $user . '/relationship', array('action' => $action), 'POST');
         }
 
         throw new InstagramException('Error: modifyRelationship() | This method requires an action command and the target user id.');
@@ -323,26 +317,22 @@ class Instagram
     /**
      * Search media by its location.
      *
-     * @param float $lat      Latitude of the center search coordinate
-     * @param float $lng      Longitude of the center search coordinate
-     * @param int   $distance Distance in metres (default is 1km (distance=1000), max. is 5km)
+     * @param float $lat Latitude of the center search coordinate
+     * @param float $lng Longitude of the center search coordinate
+     * @param int $distance Distance in metres (default is 1km (distance=1000), max. is 5km)
      *
      * @return mixed
      */
     public function searchMedia($lat, $lng, $distance = 1000)
     {
-        return $this->_makeCall(
-            'media/search',
-            array(
-                'lat'      => $lat,
-                'lng'      => $lng,
-                'distance' => $distance,
-            )
-        );
+        return $this->_makeCall('media/search', array(
+            'lat' => $lat,
+            'lng' => $lng,
+            'distance' => $distance
+        ));
     }
 
     /**
-     * @deprecated
      * Get media by its id.
      *
      * @param int $id Instagram media ID
@@ -351,7 +341,7 @@ class Instagram
      */
     public function getMedia($id)
     {
-        return $this->_makeCall('media/'.$id);
+        return $this->_makeCall('media/' . $id);
     }
 
     /**
@@ -375,16 +365,16 @@ class Instagram
      */
     public function getTag($name)
     {
-        return $this->_makeCall('tags/'.$name);
+        return $this->_makeCall('tags/' . $name);
     }
 
     /**
      * Get a recently tagged media.
      *
-     * @param string $name       Valid tag name
-     * @param int    $limit      Limit of returned results
-     * @param int    $min_tag_id Return media before this min_tag_id
-     * @param int    $max_tag_id Return media after this max_tag_id
+     * @param string $name Valid tag name
+     * @param int $limit Limit of returned results
+     * @param int $min_tag_id Return media before this min_tag_id
+     * @param int $max_tag_id Return media after this max_tag_id
      *
      * @return mixed
      */
@@ -402,7 +392,7 @@ class Instagram
             $params['max_tag_id'] = $max_tag_id;
         }
 
-        return $this->_makeCall('tags/'.$name.'/media/recent', $params);
+        return $this->_makeCall('tags/' . $name . '/media/recent', $params);
     }
 
     /**
@@ -415,7 +405,7 @@ class Instagram
      */
     public function getMediaLikes($id)
     {
-        return $this->_makeCall('media/'.$id.'/likes');
+        return $this->_makeCall('media/' . $id . '/likes');
     }
 
     /**
@@ -429,35 +419,35 @@ class Instagram
      */
     public function getMediaComments($id)
     {
-        return $this->_makeCall('media/'.$id.'/comments');
+        return $this->_makeCall('media/' . $id . '/comments');
     }
 
     /**
      * @deprecated
      * Add a comment on a media.
      *
-     * @param int    $id   Instagram media ID
+     * @param int $id Instagram media ID
      * @param string $text Comment content
      *
      * @return mixed
      */
     public function addMediaComment($id, $text)
     {
-        return $this->_makeCall('media/'.$id.'/comments', array('text' => $text), 'POST');
+        return $this->_makeCall('media/' . $id . '/comments', array('text' => $text), 'POST');
     }
 
     /**
      * @deprecated
      * Remove user comment on a media.
      *
-     * @param int    $id        Instagram media ID
+     * @param int $id Instagram media ID
      * @param string $commentID User comment ID
      *
      * @return mixed
      */
     public function deleteMediaComment($id, $commentID)
     {
-        return $this->_makeCall('media/'.$id.'/comments/'.$commentID, null, 'DELETE');
+        return $this->_makeCall('media/' . $id . '/comments/' . $commentID, null, 'DELETE');
     }
 
     /**
@@ -470,7 +460,7 @@ class Instagram
      */
     public function likeMedia($id)
     {
-        return $this->_makeCall('media/'.$id.'/likes', null, 'POST');
+        return $this->_makeCall('media/' . $id . '/likes', null, 'POST');
     }
 
     /**
@@ -483,7 +473,7 @@ class Instagram
      */
     public function deleteLikedMedia($id)
     {
-        return $this->_makeCall('media/'.$id.'/likes', null, 'DELETE');
+        return $this->_makeCall('media/' . $id . '/likes', null, 'DELETE');
     }
 
     /**
@@ -495,13 +485,13 @@ class Instagram
      */
     public function getLocation($id)
     {
-        return $this->_makeCall('locations/'.$id);
+        return $this->_makeCall('locations/' . $id);
     }
 
     /**
      * Get recent media from a given location.
      *
-     * @param int $id     Instagram location ID
+     * @param int $id Instagram location ID
      * @param int $min_id Return media before this min_id
      * @param int $max_id Return media after this max_id
      *
@@ -518,28 +508,28 @@ class Instagram
             $params['max_id'] = $max_id;
         }
 
-        return $this->_makeCall('locations/'.$id.'/media/recent', $params);
+        return $this->_makeCall('locations/' . $id . '/media/recent', $params);
     }
 
     /**
      * Get recent media from a given location.
      *
-     * @param float $lat                Latitude of the center search coordinate
-     * @param float $lng                Longitude of the center search coordinate
-     * @param int   $distance           Distance in meter (max. distance: 5km = 5000)
-     * @param int   $facebook_places_id Returns a location mapped off of a
-     *                                  Facebook places id. If used, a Foursquare
-     *                                  id and lat, lng are not required.
-     * @param int   $foursquare_id      Returns a location mapped off of a foursquare v2
-     *                                  api location id. If used, you are not
-     *                                  required to use lat and lng.
+     * @param float $lat Latitude of the center search coordinate
+     * @param float $lng Longitude of the center search coordinate
+     * @param int $distance Distance in meter (max. distance: 5km = 5000)
+     * @param int $facebook_places_id Returns a location mapped off of a
+     *                                Facebook places id. If used, a Foursquare
+     *                                id and lat, lng are not required.
+     * @param int $foursquare_id Returns a location mapped off of a foursquare v2
+     *                                api location id. If used, you are not
+     *                                required to use lat and lng.
      *
      * @return mixed
      */
     public function searchLocation($lat, $lng, $distance = 1000, $facebook_places_id = null, $foursquare_id = null)
     {
-        $params['lat']      = $lat;
-        $params['lng']      = $lng;
+        $params['lat'] = $lat;
+        $params['lng'] = $lng;
         $params['distance'] = $distance;
         if (isset($facebook_places_id)) {
             $params['facebook_places_id'] = $facebook_places_id;
@@ -554,8 +544,8 @@ class Instagram
     /**
      * Pagination feature.
      *
-     * @param object $obj   Instagram object returned by a method
-     * @param int    $limit Limit of returned results
+     * @param object $obj Instagram object returned by a method
+     * @param int $limit Limit of returned results
      *
      * @return mixed
      *
@@ -575,7 +565,7 @@ class Instagram
             }
 
             $function = str_replace(self::API_URL, '', $apiCall[0]);
-            $count    = ($limit) ? $limit : count($obj->data);
+            $count = ($limit) ? $limit : count($obj->data);
 
             if (isset($obj->pagination->next_max_tag_id)) {
                 return $this->_makeCall($function, array('max_tag_id' => $obj->pagination->next_max_tag_id, 'count' => $count));
@@ -589,19 +579,19 @@ class Instagram
     /**
      * Get the OAuth data of a user by the returned callback code.
      *
-     * @param string $code  OAuth2 code variable (after a successful login)
-     * @param bool   $token If it's true, only the access token will be returned
+     * @param string $code OAuth2 code variable (after a successful login)
+     * @param bool $token If it's true, only the access token will be returned
      *
      * @return mixed
      */
     public function getOAuthToken($code, $token = false)
     {
         $apiData = array(
-            'grant_type'    => 'authorization_code',
-            'client_id'     => $this->getApiKey(),
+            'grant_type' => 'authorization_code',
+            'client_id' => $this->getApiKey(),
             'client_secret' => $this->getApiSecret(),
-            'redirect_uri'  => $this->getApiCallback(),
-            'code'          => $code,
+            'redirect_uri' => $this->getApiCallback(),
+            'code' => $code
         );
 
         $result = $this->_makeOAuthCall($apiData);
@@ -613,8 +603,8 @@ class Instagram
      * The call operator.
      *
      * @param string $function API resource path
-     * @param array  $params   Additional request parameters
-     * @param string $method   Request type GET|POST
+     * @param array $params Additional request parameters
+     * @param string $method Request type GET|POST
      *
      * @return mixed
      *
@@ -626,21 +616,21 @@ class Instagram
             throw new InstagramException("Error: _makeCall() | $function - This method requires an authenticated users access token.");
         }
 
-        $authMethod = '?access_token='.$this->getAccessToken();
+        $authMethod = '?access_token=' . $this->getAccessToken();
 
         $paramString = null;
 
         if (isset($params) && is_array($params)) {
-            $paramString = '&'.http_build_query($params);
+            $paramString = '&' . http_build_query($params);
         }
 
-        $apiCall = self::API_URL.$function.$authMethod.(('GET' === $method) ? $paramString : null);
+        $apiCall = self::API_URL . $function . $authMethod . (('GET' === $method) ? $paramString : null);
 
         // we want JSON
         $headerData = array('Accept: application/json');
 
         if ($this->_signedheader) {
-            $apiCall .= (strstr($apiCall, '?') ? '&' : '?').'sig='.$this->_signHeader($function, $authMethod, $params);
+            $apiCall .= (strstr($apiCall, '?') ? '&' : '?') . 'sig=' . $this->_signHeader($function, $authMethod, $params);
         }
 
         $ch = curl_init();
@@ -676,7 +666,7 @@ class Instagram
         }
 
         if (!$jsonData) {
-            throw new InstagramException('Error: _makeCall() - cURL error: '.curl_error($ch));
+            throw new InstagramException('Error: _makeCall() - cURL error: ' . curl_error($ch));
         }
 
         curl_close($ch);
@@ -708,7 +698,7 @@ class Instagram
         $jsonData = curl_exec($ch);
 
         if (!$jsonData) {
-            throw new InstagramException('Error: _makeOAuthCall() - cURL error: '.curl_error($ch));
+            throw new InstagramException('Error: _makeOAuthCall() - cURL error: ' . curl_error($ch));
         }
 
         curl_close($ch);
@@ -734,10 +724,10 @@ class Instagram
             list($key, $value) = explode('=', substr($authMethod, 1), 2);
             $params[$key] = $value;
         }
-        $baseString = '/'.$endpoint;
+        $baseString = '/' . $endpoint;
         ksort($params);
         foreach ($params as $key => $value) {
-            $baseString .= '|'.$key.'='.$value;
+            $baseString .= '|' . $key . '=' . $value;
         }
         $signature = hash_hmac('sha256', $baseString, $this->_apisecret, false);
 

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -8,11 +8,11 @@ namespace MetzWeb\Instagram;
  * API Documentation: http://instagram.com/developer/
  * Class Documentation: https://github.com/cosenary/Instagram-PHP-API
  *
- * @author Christian Metz
- * @since 30.10.2011
+ * @author    Christian Metz
+ * @since     30.10.2011
  * @copyright Christian Metz - MetzWeb Networks 2011-2014
- * @version 2.2
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
+ * @version   2.2
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
  */
 class Instagram
 {
@@ -79,7 +79,7 @@ class Instagram
      * @var string[]
      */
     private $_actions = array('follow', 'unfollow', 'approve', 'ignore');
-    
+
     /**
      * Rate limit.
      *
@@ -123,31 +123,26 @@ class Instagram
     public function getLoginUrl($scopes = array('basic'))
     {
         if (is_array($scopes) && count(array_intersect($scopes, $this->_scopes)) === count($scopes)) {
-            return self::API_OAUTH_URL . '?client_id=' . $this->getApiKey() . '&redirect_uri=' . urlencode($this->getApiCallback()) . '&scope=' . implode('+',
-                $scopes) . '&response_type=code';
+            return self::API_OAUTH_URL.'?client_id='.$this->getApiKey().'&redirect_uri='.urlencode($this->getApiCallback()).'&scope='.implode(
+                    '+',
+                    $scopes
+                ).'&response_type=code';
         }
 
         throw new InstagramException("Error: getLoginUrl() - The parameter isn't an array or invalid scope permissions used.");
     }
 
     /**
-     * Search for a user.
-     *
-     * @param string $name Instagram username
-     * @param int $limit Limit of returned results
+     * Get information about the owner of the access_token.
+     * https://api.instagram.com/v1/users/self/?access_token=ACCESS-TOKEN
+     * PARAMETERS
+     * ACCESS_TOKEN    A valid access token.
      *
      * @return mixed
      */
-    public function searchUser($name, $limit = 0)
+    public function searchUser()
     {
-        $params = array();
-
-        $params['q'] = $name;
-        if ($limit > 0) {
-            $params['count'] = $limit;
-        }
-
-        return $this->_makeCall('users/search', $params);
+        return $this->_makeCall('users/self');
     }
 
     /**
@@ -163,20 +158,25 @@ class Instagram
             $id = 'self';
         }
 
-        return $this->_makeCall('users/' . $id);
+        return $this->_makeCall('users/'.$id);
     }
 
     /**
-     * Get user recent media.
+     * Get the most recent media published by the owner of the access_token.
+     * https://api.instagram.com/v1/users/self/media/recent/?access_token=ACCESS-TOKEN
+     * PARAMETERS
+     * ACCESS_TOKEN    A valid access token.
+     * MAX_ID    Return media earlier than this max_id.
+     * MIN_ID    Return media later than this min_id.
+     * COUNT    Count of media to return.
      *
-     * @param int|string $id Instagram user ID
-     * @param int $limit Limit of returned results
+     * @param int $limit  Limit of returned results
      * @param int $min_id Return media later than this min_id
      * @param int $max_id Return media earlier than this max_id
      *
      * @return mixed
      */
-    public function getUserMedia($id = 'self', $limit = 0, $min_id = null, $max_id = null)
+    public function getUserMedia($limit = 0, $min_id = null, $max_id = null)
     {
         $params = array();
 
@@ -190,13 +190,14 @@ class Instagram
             $params['max_id'] = $max_id;
         }
 
-        return $this->_makeCall('users/' . $id . '/media/recent', $params);
+        return $this->_makeCall('users/self/media/recent', $params);
     }
 
     /**
+     * @deprecated
      * Get the liked photos of a user.
      *
-     * @param int $limit Limit of returned results
+     * @param int $limit       Limit of returned results
      * @param int $max_like_id Return media liked before this id
      *
      * @return mixed
@@ -216,11 +217,11 @@ class Instagram
     }
 
     /**
-     * DEPRECATED
+     * @deprecated
      * Get the list of users this user follows
      *
-     * @param int|string $id Instagram user ID.
-     * @param int $limit Limit of returned results
+     * @param int|string $id    Instagram user ID.
+     * @param int        $limit Limit of returned results
      *
      * @return void
      */
@@ -230,6 +231,7 @@ class Instagram
     }
 
     /**
+     * @deprecated
      * Get the list of users the authenticated user follows.
      *
      * @return mixed
@@ -242,15 +244,15 @@ class Instagram
             $params['count'] = $limit;
         }
 
-        return $this->_makeCall('users/' . $id . '/follows', $params);
+        return $this->_makeCall('users/'.$id.'/follows', $params);
     }
 
     /**
-     * DEPRECATED
+     * @deprecated
      * Get the list of users this user is followed by.
      *
-     * @param int|string $id Instagram user ID
-     * @param int $limit Limit of returned results
+     * @param int|string $id    Instagram user ID
+     * @param int        $limit Limit of returned results
      *
      * @return void
      */
@@ -260,6 +262,7 @@ class Instagram
     }
 
     /**
+     * @deprecated
      * Get the list of users this user is followed by.
      *
      * @return mixed
@@ -272,10 +275,11 @@ class Instagram
             $params['count'] = $limit;
         }
 
-        return $this->_makeCall('users/' . $id . '/followed-by', $params);
+        return $this->_makeCall('users/'.$id.'/followed-by', $params);
     }
 
     /**
+     * @deprecated
      * Get information about a relationship to another user.
      *
      * @param int $id Instagram user ID
@@ -284,9 +288,9 @@ class Instagram
      */
     public function getUserRelationship($id)
     {
-        return $this->_makeCall('users/' . $id . '/relationship');
+        return $this->_makeCall('users/'.$id.'/relationship');
     }
-    
+
     /**
      * Get the value of X-RateLimit-Remaining header field.
      *
@@ -301,7 +305,7 @@ class Instagram
      * Modify the relationship between the current user and the target user.
      *
      * @param string $action Action command (follow/unfollow/approve/ignore)
-     * @param int $user Target user ID
+     * @param int    $user   Target user ID
      *
      * @return mixed
      *
@@ -310,7 +314,7 @@ class Instagram
     public function modifyRelationship($action, $user)
     {
         if (in_array($action, $this->_actions) && isset($user)) {
-            return $this->_makeCall('users/' . $user . '/relationship', array('action' => $action), 'POST');
+            return $this->_makeCall('users/'.$user.'/relationship', array('action' => $action), 'POST');
         }
 
         throw new InstagramException('Error: modifyRelationship() | This method requires an action command and the target user id.');
@@ -319,22 +323,26 @@ class Instagram
     /**
      * Search media by its location.
      *
-     * @param float $lat Latitude of the center search coordinate
-     * @param float $lng Longitude of the center search coordinate
-     * @param int $distance Distance in metres (default is 1km (distance=1000), max. is 5km)
+     * @param float $lat      Latitude of the center search coordinate
+     * @param float $lng      Longitude of the center search coordinate
+     * @param int   $distance Distance in metres (default is 1km (distance=1000), max. is 5km)
      *
      * @return mixed
      */
     public function searchMedia($lat, $lng, $distance = 1000)
     {
-        return $this->_makeCall('media/search', array(
-            'lat' => $lat,
-            'lng' => $lng,
-            'distance' => $distance
-        ));
+        return $this->_makeCall(
+            'media/search',
+            array(
+                'lat'      => $lat,
+                'lng'      => $lng,
+                'distance' => $distance,
+            )
+        );
     }
 
     /**
+     * @deprecated
      * Get media by its id.
      *
      * @param int $id Instagram media ID
@@ -343,7 +351,7 @@ class Instagram
      */
     public function getMedia($id)
     {
-        return $this->_makeCall('media/' . $id);
+        return $this->_makeCall('media/'.$id);
     }
 
     /**
@@ -367,16 +375,16 @@ class Instagram
      */
     public function getTag($name)
     {
-        return $this->_makeCall('tags/' . $name);
+        return $this->_makeCall('tags/'.$name);
     }
 
     /**
      * Get a recently tagged media.
      *
-     * @param string $name Valid tag name
-     * @param int $limit Limit of returned results
-     * @param int $min_tag_id Return media before this min_tag_id
-     * @param int $max_tag_id Return media after this max_tag_id
+     * @param string $name       Valid tag name
+     * @param int    $limit      Limit of returned results
+     * @param int    $min_tag_id Return media before this min_tag_id
+     * @param int    $max_tag_id Return media after this max_tag_id
      *
      * @return mixed
      */
@@ -394,10 +402,11 @@ class Instagram
             $params['max_tag_id'] = $max_tag_id;
         }
 
-        return $this->_makeCall('tags/' . $name . '/media/recent', $params);
+        return $this->_makeCall('tags/'.$name.'/media/recent', $params);
     }
 
     /**
+     * @deprecated
      * Get a list of users who have liked this media.
      *
      * @param int $id Instagram media ID
@@ -406,10 +415,12 @@ class Instagram
      */
     public function getMediaLikes($id)
     {
-        return $this->_makeCall('media/' . $id . '/likes');
+        return $this->_makeCall('media/'.$id.'/likes');
     }
 
     /**
+     * @deprecated
+     *(Deprecation not relevant when fetching comments for self media)
      * Get a list of comments for this media.
      *
      * @param int $id Instagram media ID
@@ -418,36 +429,39 @@ class Instagram
      */
     public function getMediaComments($id)
     {
-        return $this->_makeCall('media/' . $id . '/comments');
+        return $this->_makeCall('media/'.$id.'/comments');
     }
 
     /**
+     * @deprecated
      * Add a comment on a media.
      *
-     * @param int $id Instagram media ID
+     * @param int    $id   Instagram media ID
      * @param string $text Comment content
      *
      * @return mixed
      */
     public function addMediaComment($id, $text)
     {
-        return $this->_makeCall('media/' . $id . '/comments', array('text' => $text), 'POST');
+        return $this->_makeCall('media/'.$id.'/comments', array('text' => $text), 'POST');
     }
 
     /**
+     * @deprecated
      * Remove user comment on a media.
      *
-     * @param int $id Instagram media ID
+     * @param int    $id        Instagram media ID
      * @param string $commentID User comment ID
      *
      * @return mixed
      */
     public function deleteMediaComment($id, $commentID)
     {
-        return $this->_makeCall('media/' . $id . '/comments/' . $commentID, null, 'DELETE');
+        return $this->_makeCall('media/'.$id.'/comments/'.$commentID, null, 'DELETE');
     }
 
     /**
+     * @deprecated
      * Set user like on a media.
      *
      * @param int $id Instagram media ID
@@ -456,10 +470,11 @@ class Instagram
      */
     public function likeMedia($id)
     {
-        return $this->_makeCall('media/' . $id . '/likes', null, 'POST');
+        return $this->_makeCall('media/'.$id.'/likes', null, 'POST');
     }
 
     /**
+     * @deprecated
      * Remove user like on a media.
      *
      * @param int $id Instagram media ID
@@ -468,7 +483,7 @@ class Instagram
      */
     public function deleteLikedMedia($id)
     {
-        return $this->_makeCall('media/' . $id . '/likes', null, 'DELETE');
+        return $this->_makeCall('media/'.$id.'/likes', null, 'DELETE');
     }
 
     /**
@@ -480,13 +495,13 @@ class Instagram
      */
     public function getLocation($id)
     {
-        return $this->_makeCall('locations/' . $id);
+        return $this->_makeCall('locations/'.$id);
     }
 
     /**
      * Get recent media from a given location.
      *
-     * @param int $id Instagram location ID
+     * @param int $id     Instagram location ID
      * @param int $min_id Return media before this min_id
      * @param int $max_id Return media after this max_id
      *
@@ -503,28 +518,28 @@ class Instagram
             $params['max_id'] = $max_id;
         }
 
-        return $this->_makeCall('locations/' . $id . '/media/recent', $params);
+        return $this->_makeCall('locations/'.$id.'/media/recent', $params);
     }
 
     /**
      * Get recent media from a given location.
      *
-     * @param float $lat Latitude of the center search coordinate
-     * @param float $lng Longitude of the center search coordinate
-     * @param int $distance Distance in meter (max. distance: 5km = 5000)
-     * @param int $facebook_places_id Returns a location mapped off of a
-     *                                Facebook places id. If used, a Foursquare
-     *                                id and lat, lng are not required.
-     * @param int $foursquare_id Returns a location mapped off of a foursquare v2
-     *                                api location id. If used, you are not
-     *                                required to use lat and lng.
+     * @param float $lat                Latitude of the center search coordinate
+     * @param float $lng                Longitude of the center search coordinate
+     * @param int   $distance           Distance in meter (max. distance: 5km = 5000)
+     * @param int   $facebook_places_id Returns a location mapped off of a
+     *                                  Facebook places id. If used, a Foursquare
+     *                                  id and lat, lng are not required.
+     * @param int   $foursquare_id      Returns a location mapped off of a foursquare v2
+     *                                  api location id. If used, you are not
+     *                                  required to use lat and lng.
      *
      * @return mixed
      */
     public function searchLocation($lat, $lng, $distance = 1000, $facebook_places_id = null, $foursquare_id = null)
     {
-        $params['lat'] = $lat;
-        $params['lng'] = $lng;
+        $params['lat']      = $lat;
+        $params['lng']      = $lng;
         $params['distance'] = $distance;
         if (isset($facebook_places_id)) {
             $params['facebook_places_id'] = $facebook_places_id;
@@ -539,8 +554,8 @@ class Instagram
     /**
      * Pagination feature.
      *
-     * @param object $obj Instagram object returned by a method
-     * @param int $limit Limit of returned results
+     * @param object $obj   Instagram object returned by a method
+     * @param int    $limit Limit of returned results
      *
      * @return mixed
      *
@@ -560,7 +575,7 @@ class Instagram
             }
 
             $function = str_replace(self::API_URL, '', $apiCall[0]);
-            $count = ($limit) ? $limit : count($obj->data);
+            $count    = ($limit) ? $limit : count($obj->data);
 
             if (isset($obj->pagination->next_max_tag_id)) {
                 return $this->_makeCall($function, array('max_tag_id' => $obj->pagination->next_max_tag_id, 'count' => $count));
@@ -574,19 +589,19 @@ class Instagram
     /**
      * Get the OAuth data of a user by the returned callback code.
      *
-     * @param string $code OAuth2 code variable (after a successful login)
-     * @param bool $token If it's true, only the access token will be returned
+     * @param string $code  OAuth2 code variable (after a successful login)
+     * @param bool   $token If it's true, only the access token will be returned
      *
      * @return mixed
      */
     public function getOAuthToken($code, $token = false)
     {
         $apiData = array(
-            'grant_type' => 'authorization_code',
-            'client_id' => $this->getApiKey(),
+            'grant_type'    => 'authorization_code',
+            'client_id'     => $this->getApiKey(),
             'client_secret' => $this->getApiSecret(),
-            'redirect_uri' => $this->getApiCallback(),
-            'code' => $code
+            'redirect_uri'  => $this->getApiCallback(),
+            'code'          => $code,
         );
 
         $result = $this->_makeOAuthCall($apiData);
@@ -598,8 +613,8 @@ class Instagram
      * The call operator.
      *
      * @param string $function API resource path
-     * @param array $params Additional request parameters
-     * @param string $method Request type GET|POST
+     * @param array  $params   Additional request parameters
+     * @param string $method   Request type GET|POST
      *
      * @return mixed
      *
@@ -611,21 +626,21 @@ class Instagram
             throw new InstagramException("Error: _makeCall() | $function - This method requires an authenticated users access token.");
         }
 
-        $authMethod = '?access_token=' . $this->getAccessToken();
+        $authMethod = '?access_token='.$this->getAccessToken();
 
         $paramString = null;
 
         if (isset($params) && is_array($params)) {
-            $paramString = '&' . http_build_query($params);
+            $paramString = '&'.http_build_query($params);
         }
 
-        $apiCall = self::API_URL . $function . $authMethod . (('GET' === $method) ? $paramString : null);
+        $apiCall = self::API_URL.$function.$authMethod.(('GET' === $method) ? $paramString : null);
 
         // we want JSON
         $headerData = array('Accept: application/json');
 
         if ($this->_signedheader) {
-            $apiCall .= (strstr($apiCall, '?') ? '&' : '?') . 'sig=' . $this->_signHeader($function, $authMethod, $params);
+            $apiCall .= (strstr($apiCall, '?') ? '&' : '?').'sig='.$this->_signHeader($function, $authMethod, $params);
         }
 
         $ch = curl_init();
@@ -654,14 +669,14 @@ class Instagram
 
         // convert header content into an array
         $headers = $this->processHeaders($headerContent);
-        
+
         // get the 'X-Ratelimit-Remaining' header value
         if (isset($headers['X-Ratelimit-Remaining'])) {
             $this->_xRateLimitRemaining = trim($headers['X-Ratelimit-Remaining']);
         }
 
         if (!$jsonData) {
-            throw new InstagramException('Error: _makeCall() - cURL error: ' . curl_error($ch));
+            throw new InstagramException('Error: _makeCall() - cURL error: '.curl_error($ch));
         }
 
         curl_close($ch);
@@ -693,7 +708,7 @@ class Instagram
         $jsonData = curl_exec($ch);
 
         if (!$jsonData) {
-            throw new InstagramException('Error: _makeOAuthCall() - cURL error: ' . curl_error($ch));
+            throw new InstagramException('Error: _makeOAuthCall() - cURL error: '.curl_error($ch));
         }
 
         curl_close($ch);
@@ -719,10 +734,10 @@ class Instagram
             list($key, $value) = explode('=', substr($authMethod, 1), 2);
             $params[$key] = $value;
         }
-        $baseString = '/' . $endpoint;
+        $baseString = '/'.$endpoint;
         ksort($params);
         foreach ($params as $key => $value) {
-            $baseString .= '|' . $key . '=' . $value;
+            $baseString .= '|'.$key.'='.$value;
         }
         $signature = hash_hmac('sha256', $baseString, $this->_apisecret, false);
 


### PR DESCRIPTION
Add @deprecated to deprecated methods.
Add some info in changelog.md.
Add note in readme.md

[changelog](https://www.instagram.com/developer/changelog/)
[endpoints](https://www.instagram.com/developer/endpoints/)

**April 4, 2018**
**The following endpoints are deprecated immediately:**

**Follows and Relationships**
- `GET /users/self/follows`
- `GET /users/self/followed-by`
- `GET /users/self/requested-by`
- `GET /users/{user-id}/relationship`
- `POST /users/{user-id}/relationship`
**Commenting on Public Content**
- `GET /media/{media-id}/comments` (Deprecation not relevant when fetching comments for self media)
- `POST /media/{media-id}/comments`
- `DEL /media/{media-id}/comments/comment-id`
**Media**
- `GET /media/{media-id}`
- `GET /media/shortcode/{shortcode}`
**Likes**
- `GET /media/{media-id}/likes`
- `POST /media/{media-id}/likes`
- `DEL /media/{media-id}/likes`
**User Search**
- `GET /users/{user-id}`
- `GET /users/{user-id}/media/recent`
- `GET /users/self/media/liked`
- `GET /users/search`


